### PR TITLE
Update for ES6

### DIFF
--- a/eslint/eslintrc.yml
+++ b/eslint/eslintrc.yml
@@ -8,6 +8,8 @@ plugins:
     - "react"
 
 parserOptions:
+    # Allow ES6 modules.
+    sourceType: 'module'
     # Allow JSX.
     ecmaFeatures:
         jsx: true


### PR DESCRIPTION
This is necessary to get this branch to lint cleanly:

https://github.com/bodylabs/skeleton-react-frontend/tree/63_webpack

Right now that branch has its own eslintrc checked in. After this change, that will no longer be needed.

Tested this with both that branch and creel-frontend, and it seems to work. Would you mind trying as well (at least for creel-frontend)?
