### PR TITLE
Update some rules for JSX and React

### DIFF
--- a/eslint/eslintrc.yml
+++ b/eslint/eslintrc.yml
@@ -24,13 +24,15 @@ globals:
 extends:
     # Extend the base Body Labs style, which is pulled in via peerDependencies.
     - '../../bodylabs-javascript-style/eslint/eslintrc-shared.yml'
+
+    # Pull in https://github.com/yannickcr/eslint-plugin-react
     - 'plugin:react/recommended'
 
 rules:
     # JSX.
-    # eslint-plugin-react is required
-    # https://github.com/yannickcr/eslint-plugin-react
     jsx-quotes: 'error'
+
+    # More JSX, from https://github.com/yannickcr/eslint-plugin-react
     react/jsx-curly-spacing: ['error', 'always']
     react/jsx-equals-spacing: ['error', 'never']
     react/jsx-indent: 'error'

--- a/eslint/eslintrc.yml
+++ b/eslint/eslintrc.yml
@@ -5,7 +5,7 @@ env:
     browser: true
 
 plugins:
-    - "react"
+    - 'react'
 
 parserOptions:
     # Allow ES6 modules.
@@ -23,15 +23,19 @@ globals:
 
 extends:
     # Extend the base Body Labs style, which is pulled in via peerDependencies.
-    "../../bodylabs-javascript-style/eslint/eslintrc-shared.yml"
+    - '../../bodylabs-javascript-style/eslint/eslintrc-shared.yml'
+    - 'plugin:react/recommended'
 
 rules:
-    # 2 means error, 1 means warning, 0 means ignore.
-
     # JSX.
     # eslint-plugin-react is required
     # https://github.com/yannickcr/eslint-plugin-react
-    jsx-quotes: 2
+    jsx-quotes: 'error'
+    react/jsx-curly-spacing: ['error', 'always']
+    react/jsx-equals-spacing: ['error', 'never']
+    react/jsx-indent: 'error'
+    react/jsx-pascal-case: 'error'
+    react/jsx-space-before-closing: 'error'
 
     # Prevent spurious warnings in JSX code.
     react/jsx-uses-react: 1

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
   "license": "MIT",
   "homepage": "https://github.com/bodylabs/bodylabs-frontend-style",
   "peerDependencies": {
-    "bodylabs-javascript-style": "*"
+    "bodylabs-javascript-style": "*",
+    "eslint": ">=2.4.0",
+    "eslint-plugin-react": ">=4.2.3"
   }
 }


### PR DESCRIPTION
Includes spaces inside braces, and lots of even more useful things like checking the correct jsx property names (i.e. `classNames` vs `class`).

I had added, but later removed, one more rule from [eslint-plugin-react](https://github.com/yannickcr/eslint-plugin-react) which is [jsx-closing-bracket-location](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-closing-bracket-location.md). I removed it because it seemed to generate spurious warnings.

Tested in creel-frontend and the blue skeleton, which both need some cleanup. Most of it is in propTypes and curly braces spacing.

@sashaverma @btparker @maxdumas
