### PR TITLE
Republish as an eslint plugin

### DIFF
--- a/eslint/frontend.yml
+++ b/eslint/frontend.yml
@@ -1,6 +1,9 @@
 env:
     browser: true
 
+plugins:
+    - 'react'
+
 parser: 'babel-eslint'
 
 parserOptions:

--- a/eslint/frontend.yml
+++ b/eslint/frontend.yml
@@ -1,11 +1,5 @@
-# Don't inherit settings from e.g. ~.
-root: true
-
 env:
     browser: true
-
-plugins:
-    - 'react'
 
 parser: 'babel-eslint'
 
@@ -24,10 +18,7 @@ globals:
     __dev_tools: true
 
 extends:
-    # Extend the base Body Labs style, which is pulled in via peerDependencies.
-    - '../../bodylabs-javascript-style/eslint/eslintrc-shared.yml'
-
-    # Pull in https://github.com/yannickcr/eslint-plugin-react
+    - 'plugin:bodylabs/common'
     - 'plugin:react/recommended'
 
 rules:

--- a/index.js
+++ b/index.js
@@ -1,0 +1,17 @@
+// Load the config from yaml, since we prefer to read yaml. Use sync methods,
+// since this module needs to export a full config.
+
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+
+const loadConfig = (name) => {
+    const configPath = path.resolve(__dirname, 'eslint', `${ name }.yml`);
+    return yaml.load(fs.readFileSync(configPath, 'utf8'));
+};
+
+module.exports = {
+    configs: {
+        frontend: loadConfig('frontend'),
+    },
+};

--- a/package.json
+++ b/package.json
@@ -1,18 +1,21 @@
 {
-  "name": "bodylabs-frontend-style",
-  "version": "2.0.1",
+  "name": "eslint-plugin-bodylabs-frontend",
+  "version": "3.0.0",
   "description": "JavaScript and SASS style for Body Labs front-end projects",
   "repository": {
     "type": "git",
-    "url": "https://github.com/bodylabs/bodylabs-frontend-style.git"
+    "url": "https://github.com/bodylabs/eslint-plugin-bodylabs-frontend.git"
   },
   "author": "Body Labs",
   "license": "MIT",
-  "homepage": "https://github.com/bodylabs/bodylabs-frontend-style",
+  "homepage": "https://github.com/bodylabs/eslint-plugin-bodylabs-frontend",
   "peerDependencies": {
     "babel-eslint": ">=6.0.2",
-    "bodylabs-javascript-style": "*",
-    "eslint": ">=2.4.0",
+    "eslint-plugin-bodylabs": "*",
+    "eslint": ">=2.13.0",
     "eslint-plugin-react": ">=4.2.3"
+  },
+  "dependencies": {
+    "js-yaml": ">=3"
   }
 }


### PR DESCRIPTION
Since this has some additional dependencies over what is required for the common linter, it makes more sense to ship this as a separate plugin.
